### PR TITLE
Fixed issue: Wrong typing on setOption and unsetOption

### DIFF
--- a/Curl.php
+++ b/Curl.php
@@ -237,7 +237,7 @@ class Curl
     /**
      * Set curl option
      *
-     * @param string $key
+     * @param int $key
      * @param mixed  $value
      *
      * @return $this
@@ -501,7 +501,7 @@ class Curl
     /**
      * Unset a single curl option
      *
-     * @param string $key
+     * @param int $key
      *
      * @return $this
      */


### PR DESCRIPTION
Code checking tools like psalm will think you are doing something wrong because the CURL constants are integers.